### PR TITLE
fix: highlight and order language selector

### DIFF
--- a/nexus/lib/widgets/language_selector.dart
+++ b/nexus/lib/widgets/language_selector.dart
@@ -33,7 +33,8 @@ class _LanguageSelectorState extends State<LanguageSelector> {
   @override
   void didUpdateWidget(covariant LanguageSelector oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.selectedIndex != widget.selectedIndex) {
+    if (oldWidget.selectedIndex != widget.selectedIndex &&
+        _controller.hasClients) {
       _controller.jumpToItem(widget.selectedIndex);
     }
   }
@@ -70,17 +71,13 @@ class _LanguageSelectorState extends State<LanguageSelector> {
   Widget _buildCollapsed(String lang) {
     return InkWell(
       onTap: () {
-        _controller.jumpToItem(widget.selectedIndex);
+        _controller.dispose();
+        _controller =
+            FixedExtentScrollController(initialItem: widget.selectedIndex);
         setState(() => _expanded = true);
       },
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(lang, style: _languageStyle(lang, true)),
-          const SizedBox(width: 8),
-          const Sparkle(color: Color(0xFF81D4FA)),
-        ],
-      ),
+      child:
+          Text(lang, style: _languageStyle(lang, false, const Color(0xFF5E35B1))),
     );
   }
 
@@ -127,19 +124,10 @@ class _LanguageSelectorState extends State<LanguageSelector> {
         children: [
           for (var i = 0; i < widget.languages.length; i++)
             Center(
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    widget.languages[i],
-                    style: _languageStyle(
-                        widget.languages[i], i == widget.selectedIndex),
-                  ),
-                  if (i == widget.selectedIndex) ...[
-                    const SizedBox(width: 8),
-                    const Sparkle(),
-                  ]
-                ],
+              child: Text(
+                widget.languages[i],
+                style: _languageStyle(
+                    widget.languages[i], i == widget.selectedIndex),
               ),
             )
         ],
@@ -147,7 +135,7 @@ class _LanguageSelectorState extends State<LanguageSelector> {
     );
   }
 
-  TextStyle _languageStyle(String language, bool selected) {
+  TextStyle _languageStyle(String language, bool selected, [Color? color]) {
     TextStyle base;
     switch (language) {
       case '日本語':
@@ -157,7 +145,7 @@ class _LanguageSelectorState extends State<LanguageSelector> {
         base = GoogleFonts.ebGaramond(fontSize: 20);
     }
     return base.copyWith(
-      color: selected ? const Color(0xFF5E35B1) : Colors.black87,
+      color: color ?? (selected ? Colors.black : Colors.black87),
     );
   }
 }


### PR DESCRIPTION
## Summary
- reinitialize picker at current selection and guard controller updates
- show selected language in violet when collapsed
- allow custom text colors for languages

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aad633f64c8332b959a58aac48c4b5