### PR TITLE
Add animated color swap on language change

### DIFF
--- a/nexus/lib/landing_page.dart
+++ b/nexus/lib/landing_page.dart
@@ -12,6 +12,7 @@ class LandingPage extends StatefulWidget {
 
 class _LandingPageState extends State<LandingPage> {
   int _selectedIndex = 0;
+  bool _isDark = false;
 
   List<String> get _languages => poems.keys.toList();
   String get _currentLang => _languages[_selectedIndex];
@@ -19,31 +20,51 @@ class _LandingPageState extends State<LandingPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Stack(
-        children: [
-          LayoutBuilder(
-            builder: (context, constraints) {
-              return SingleChildScrollView(
-                padding: const EdgeInsets.all(24),
-                child: ConstrainedBox(
-                  constraints: BoxConstraints(minHeight: constraints.maxHeight),
-                  child: Center(
-                    child: Text(
-                      poems[_currentLang]!,
-                      textAlign: TextAlign.center,
-                      style: _poemStyle(_currentLang),
+      body: AnimatedContainer(
+        duration: const Duration(milliseconds: 600),
+        color: _isDark ? Colors.black : Colors.white,
+        child: Stack(
+          children: [
+            LayoutBuilder(
+              builder: (context, constraints) {
+                return SingleChildScrollView(
+                  padding: const EdgeInsets.all(24),
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                    child: Center(
+                      child: AnimatedSwitcher(
+                        duration: const Duration(milliseconds: 800),
+                        transitionBuilder: (child, animation) {
+                          return RotationTransition(
+                            turns: animation,
+                            child: FadeTransition(opacity: animation, child: child),
+                          );
+                        },
+                        child: Text(
+                          poems[_currentLang]!,
+                          key: ValueKey(_currentLang + (_isDark ? 'dark' : 'light')),
+                          textAlign: TextAlign.center,
+                          style: _poemStyle(_currentLang).copyWith(
+                            color: _isDark ? Colors.white : Colors.black,
+                          ),
+                        ),
+                      ),
                     ),
                   ),
-                ),
-              );
-            },
-          ),
-          LanguageSelector(
-            languages: _languages,
-            selectedIndex: _selectedIndex,
-            onChanged: (i) => setState(() => _selectedIndex = i),
-          ),
-        ],
+                );
+              },
+            ),
+            LanguageSelector(
+              languages: _languages,
+              selectedIndex: _selectedIndex,
+              isDark: _isDark,
+              onChanged: (i) => setState(() {
+                _selectedIndex = i;
+                _isDark = !_isDark;
+              }),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/nexus/lib/widgets/language_selector.dart
+++ b/nexus/lib/widgets/language_selector.dart
@@ -7,12 +7,14 @@ class LanguageSelector extends StatefulWidget {
   final List<String> languages;
   final int selectedIndex;
   final ValueChanged<int> onChanged;
+  final bool isDark;
 
   const LanguageSelector({
     super.key,
     required this.languages,
     required this.selectedIndex,
     required this.onChanged,
+    required this.isDark,
   });
 
   @override
@@ -76,8 +78,11 @@ class _LanguageSelectorState extends State<LanguageSelector> {
             FixedExtentScrollController(initialItem: widget.selectedIndex);
         setState(() => _expanded = true);
       },
-      child:
-          Text(lang, style: _languageStyle(lang, false, const Color(0xFF5E35B1))),
+      child: Text(
+        lang,
+        style: _languageStyle(
+            lang, false, widget.isDark ? Colors.white : const Color(0xFF5E35B1)),
+      ),
     );
   }
 
@@ -145,7 +150,10 @@ class _LanguageSelectorState extends State<LanguageSelector> {
         base = GoogleFonts.ebGaramond(fontSize: 20);
     }
     return base.copyWith(
-      color: color ?? (selected ? Colors.black : Colors.black87),
+      color: color ??
+          (selected
+              ? (widget.isDark ? Colors.white : Colors.black)
+              : (widget.isDark ? Colors.white70 : Colors.black87)),
     );
   }
 }


### PR DESCRIPTION
## Summary
- Switch between light and dark backgrounds when language changes
- Animate poem text with a swirling transition
- Adapt language selector colors for visibility in both themes

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab025743ec8332b8012b6169089cd3