### PR TITLE
Add star menu with portal and login options

### DIFF
--- a/nexus/lib/landing_page.dart
+++ b/nexus/lib/landing_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'data/poems.dart';
 import 'widgets/language_selector.dart';
+import 'widgets/star_menu.dart';
 
 class LandingPage extends StatefulWidget {
   const LandingPage({super.key});
@@ -62,6 +63,11 @@ class _LandingPageState extends State<LandingPage> {
                 _selectedIndex = i;
                 _isDark = !_isDark;
               }),
+            ),
+            const Positioned(
+              top: 16,
+              left: 16,
+              child: StarMenu(),
             ),
           ],
         ),

--- a/nexus/lib/widgets/star_menu.dart
+++ b/nexus/lib/widgets/star_menu.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+import 'sparkle.dart';
+
+class StarMenu extends StatefulWidget {
+  const StarMenu({super.key});
+
+  @override
+  State<StarMenu> createState() => _StarMenuState();
+}
+
+class _StarMenuState extends State<StarMenu> {
+  bool _open = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (_open) ...[
+          Tooltip(
+            message: 'explore stellaria',
+            child: _buildOption(
+              icon: Icons.travel_explore,
+              onTap: () {
+                // Placeholder for portal action
+              },
+            ),
+          ),
+          const SizedBox(width: 8),
+          Tooltip(
+            message: 'login',
+            child: _buildOption(
+              icon: Icons.login,
+              onTap: () {
+                // Placeholder for login action
+              },
+            ),
+          ),
+          const SizedBox(width: 8),
+        ],
+        InkWell(
+          onTap: () => setState(() => _open = !_open),
+          child: const Sparkle(size: 32, color: Color(0xFFFFD700)),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildOption({required IconData icon, VoidCallback? onTap}) {
+    return Material(
+      color: Colors.deepPurpleAccent,
+      shape: const CircleBorder(),
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(10),
+          child: Icon(icon, color: Colors.white),
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add animated star button with expandable options
- Include portal and login icons with tooltips
- Integrate menu into landing page

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0d84be8483328fa051315ce096d9