### PR TITLE
Add star menu with portal and login options

### DIFF
--- a/nexus/lib/landing_page.dart
+++ b/nexus/lib/landing_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'data/poems.dart';
 import 'widgets/language_selector.dart';
+import 'widgets/star_menu.dart';
 
 class LandingPage extends StatefulWidget {
   const LandingPage({super.key});
@@ -62,6 +63,11 @@ class _LandingPageState extends State<LandingPage> {
                 _selectedIndex = i;
                 _isDark = !_isDark;
               }),
+            ),
+            Positioned(
+              top: 16,
+              left: 16,
+              child: StarMenu(isDark: _isDark),
             ),
           ],
         ),

--- a/nexus/lib/widgets/sparkle.dart
+++ b/nexus/lib/widgets/sparkle.dart
@@ -3,8 +3,13 @@ import 'package:flutter/material.dart';
 class Sparkle extends StatefulWidget {
   final Color color;
   final double size;
+  final bool animate;
 
-  const Sparkle({super.key, this.color = const Color(0xFFB3E5FC), this.size = 12});
+  const Sparkle(
+      {super.key,
+      this.color = const Color(0xFFB3E5FC),
+      this.size = 12,
+      this.animate = true});
 
   @override
   State<Sparkle> createState() => _SparkleState();
@@ -20,7 +25,21 @@ class _SparkleState extends State<Sparkle>
     _controller = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 1200),
-    )..repeat(reverse: true);
+    );
+    if (widget.animate) {
+      _controller.repeat(reverse: true);
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant Sparkle oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.animate && !_controller.isAnimating) {
+      _controller.repeat(reverse: true);
+    } else if (!widget.animate && _controller.isAnimating) {
+      _controller.stop();
+      _controller.value = 0;
+    }
   }
 
   @override
@@ -34,9 +53,9 @@ class _SparkleState extends State<Sparkle>
     return AnimatedBuilder(
       animation: _controller,
       builder: (context, child) {
-        final t = _controller.value;
-        final color = Color.lerp(
-            widget.color.withOpacity(0.6), widget.color, t)!;
+        final t = widget.animate ? _controller.value : 0.5;
+        final color =
+            Color.lerp(widget.color.withOpacity(0.6), widget.color, t)!;
         final size = widget.size * (0.8 + 0.4 * t);
         return Container(
           alignment: Alignment.center,

--- a/nexus/lib/widgets/star_menu.dart
+++ b/nexus/lib/widgets/star_menu.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+
+import 'sparkle.dart';
+
+class StarMenu extends StatefulWidget {
+  final bool isDark;
+
+  const StarMenu({super.key, required this.isDark});
+
+  @override
+  State<StarMenu> createState() => _StarMenuState();
+}
+
+class _StarMenuState extends State<StarMenu> {
+  bool _open = false;
+  bool _hovering = false;
+
+  static const double _hoverRadius = 40;
+
+  @override
+  Widget build(BuildContext context) {
+    final starColor = widget.isDark ? Colors.grey[300]! : Colors.grey[800]!;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (_open) ...[
+          Tooltip(
+            message: 'explore stellaria',
+            child: _buildOption(
+              icon: Icons.travel_explore,
+              onTap: () {
+                // Placeholder for portal action
+              },
+            ),
+          ),
+          const SizedBox(width: 8),
+          Tooltip(
+            message: 'login',
+            child: _buildOption(
+              icon: Icons.login,
+              onTap: () {
+                // Placeholder for login action
+              },
+            ),
+          ),
+          const SizedBox(width: 8),
+        ],
+        MouseRegion(
+          onExit: (_) => setState(() => _hovering = false),
+          onHover: (e) {
+            final center = const Offset(_hoverRadius, _hoverRadius);
+            final distance = (e.localPosition - center).distance;
+            final close = distance <= _hoverRadius;
+            if (close != _hovering) {
+              setState(() => _hovering = close);
+            }
+          },
+          child: SizedBox(
+            width: _hoverRadius * 2,
+            height: _hoverRadius * 2,
+            child: Center(
+              child: InkWell(
+                onTap: () => setState(() => _open = !_open),
+                child: Sparkle(
+                  size: 32,
+                  color: starColor,
+                  animate: _hovering,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildOption({required IconData icon, VoidCallback? onTap}) {
+    return Material(
+      color: Colors.deepPurpleAccent,
+      shape: const CircleBorder(),
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(10),
+          child: Icon(icon, color: Colors.white),
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add animated star button with expandable options
- Include portal and login icons with tooltips
- Integrate menu into landing page
- Animate star only on hover and adapt star color to theme

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0d84be8483328fa051315ce096d9