### PR TITLE
Move language selector to bottom right

### DIFF
--- a/nexus/lib/widgets/language_selector.dart
+++ b/nexus/lib/widgets/language_selector.dart
@@ -60,9 +60,9 @@ class _LanguageSelectorState extends State<LanguageSelector> {
             ),
           ),
         Align(
-          alignment: Alignment.centerRight,
+          alignment: Alignment.bottomRight,
           child: Padding(
-            padding: const EdgeInsets.only(right: 16),
+            padding: const EdgeInsets.only(right: 16, bottom: 16),
             child: _expanded ? _buildWheel() : _buildCollapsed(lang),
           ),
         ),


### PR DESCRIPTION
## Summary
- Reposition language selector to bottom-right corner with proper padding

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ab1c512ac48332b45a7271d11238bb