### PR TITLE
feat: allow keyboard navigation in language selector

### DIFF
--- a/nexus/lib/widgets/language_selector.dart
+++ b/nexus/lib/widgets/language_selector.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'sparkle.dart';
 
@@ -87,13 +88,41 @@ class _LanguageSelectorState extends State<LanguageSelector> {
   }
 
   Widget _buildWheel() {
-    return SizedBox(
-      height: 150,
-      width: 120,
-      child: CupertinoPicker(
-        scrollController: _controller,
-        itemExtent: 50,
-        onSelectedItemChanged: widget.onChanged,
+    return Focus(
+      autofocus: true,
+      onKey: (node, event) {
+        if (event is RawKeyDownEvent) {
+          if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            final newIndex = _controller.selectedItem > 0
+                ? _controller.selectedItem - 1
+                : _controller.selectedItem;
+            if (newIndex != _controller.selectedItem) {
+              _controller.animateToItem(newIndex,
+                  duration: const Duration(milliseconds: 200),
+                  curve: Curves.easeInOut);
+            }
+            return KeyEventResult.handled;
+          } else if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+            final newIndex = _controller.selectedItem < widget.languages.length - 1
+                ? _controller.selectedItem + 1
+                : _controller.selectedItem;
+            if (newIndex != _controller.selectedItem) {
+              _controller.animateToItem(newIndex,
+                  duration: const Duration(milliseconds: 200),
+                  curve: Curves.easeInOut);
+            }
+            return KeyEventResult.handled;
+          }
+        }
+        return KeyEventResult.ignored;
+      },
+      child: SizedBox(
+        height: 150,
+        width: 120,
+        child: CupertinoPicker(
+          scrollController: _controller,
+          itemExtent: 50,
+          onSelectedItemChanged: widget.onChanged,
           selectionOverlay: Stack(
             alignment: Alignment.center,
             children: [
@@ -126,16 +155,17 @@ class _LanguageSelectorState extends State<LanguageSelector> {
               ),
             ],
           ),
-        children: [
-          for (var i = 0; i < widget.languages.length; i++)
-            Center(
-              child: Text(
-                widget.languages[i],
-                style: _languageStyle(
-                    widget.languages[i], i == widget.selectedIndex),
-              ),
-            )
-        ],
+          children: [
+            for (var i = 0; i < widget.languages.length; i++)
+              Center(
+                child: Text(
+                  widget.languages[i],
+                  style: _languageStyle(
+                      widget.languages[i], i == widget.selectedIndex),
+                ),
+              )
+          ],
+        ),
       ),
     );
   }

--- a/nexus/test/landing_page_test.dart
+++ b/nexus/test/landing_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart';
 import 'package:nexus/main.dart';
 
 void main() {
@@ -20,5 +21,23 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.textContaining('Pod žiarivým hviezdnym nebom'), findsOneWidget);
+  });
+
+  testWidgets('Poem changes with arrow keys when selector is open',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const NexusApp());
+
+    await tester.tap(find.text('English'));
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Unter sternenklaren Weiten'), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Under starlit skies'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- allow language picker to respond to up/down arrow keys
- test language switching using keyboard navigation

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab26b78d688332816940214f21efa5