### PR TITLE
Improve star menu animation and spacing

### DIFF
--- a/nexus/lib/widgets/star_menu.dart
+++ b/nexus/lib/widgets/star_menu.dart
@@ -11,65 +11,87 @@ class StarMenu extends StatefulWidget {
   State<StarMenu> createState() => _StarMenuState();
 }
 
-class _StarMenuState extends State<StarMenu> {
+class _StarMenuState extends State<StarMenu> with SingleTickerProviderStateMixin {
   bool _open = false;
   bool _hovering = false;
 
-  static const double _hoverRadius = 40;
+  static const double _spacing = 8;
+
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 250),
+  );
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _toggle() {
+    if (_open) {
+      _controller.reverse();
+    } else {
+      _controller.forward();
+    }
+    setState(() => _open = !_open);
+  }
 
   @override
   Widget build(BuildContext context) {
     final starColor = widget.isDark ? Colors.grey[300]! : Colors.grey[800]!;
+    final animation = CurvedAnimation(
+      parent: _controller,
+      curve: Curves.easeInOut,
+    );
+
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
         MouseRegion(
+          onEnter: (_) => setState(() => _hovering = true),
           onExit: (_) => setState(() => _hovering = false),
-          onHover: (e) {
-            final center = const Offset(_hoverRadius, _hoverRadius);
-            final distance = (e.localPosition - center).distance;
-            final close = distance <= _hoverRadius;
-            if (close != _hovering) {
-              setState(() => _hovering = close);
-            }
-          },
-          child: SizedBox(
-            width: _hoverRadius * 2,
-            height: _hoverRadius * 2,
-            child: Center(
-              child: InkWell(
-                onTap: () => setState(() => _open = !_open),
-                child: Sparkle(
-                  size: 32,
-                  color: starColor,
-                  animate: _hovering,
-                ),
-              ),
+          child: InkWell(
+            onTap: _toggle,
+            child: Sparkle(
+              size: 32,
+              color: starColor,
+              animate: _hovering,
             ),
           ),
         ),
-        if (_open) ...[
-          const SizedBox(height: 8),
-          Tooltip(
-            message: 'explore stellaria',
-            child: _buildOption(
-              icon: Icons.travel_explore,
-              onTap: () {
-                // Placeholder for portal action
-              },
+        SizeTransition(
+          sizeFactor: animation,
+          axisAlignment: -1.0,
+          child: FadeTransition(
+            opacity: animation,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const SizedBox(height: _spacing),
+                Tooltip(
+                  message: 'explore stellaria',
+                  child: _buildOption(
+                    icon: Icons.travel_explore,
+                    onTap: () {
+                      // Placeholder for portal action
+                    },
+                  ),
+                ),
+                const SizedBox(height: _spacing),
+                Tooltip(
+                  message: 'login',
+                  child: _buildOption(
+                    icon: Icons.login,
+                    onTap: () {
+                      // Placeholder for login action
+                    },
+                  ),
+                ),
+              ],
             ),
           ),
-          const SizedBox(height: 8),
-          Tooltip(
-            message: 'login',
-            child: _buildOption(
-              icon: Icons.login,
-              onTap: () {
-                // Placeholder for login action
-              },
-            ),
-          ),
-        ],
+        ),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- align options with star trigger and keep spacing consistent
- add smooth slide/fade animation for menu open and close

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2d249a3083329a5a1bda1e54f85a