### PR TITLE
Refine menu shadows for circular feel

### DIFF
--- a/nexus/lib/widgets/language_selector.dart
+++ b/nexus/lib/widgets/language_selector.dart
@@ -134,13 +134,6 @@ class _LanguageSelectorState extends State<LanguageSelector> {
                     begin: Alignment.topLeft,
                     end: Alignment.bottomRight,
                   ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.blueAccent.withOpacity(0.4),
-                      blurRadius: 8,
-                      offset: Offset(2, 4),
-                    ),
-                  ],
                 ),
               ),
               const Positioned(

--- a/nexus/lib/widgets/sparkle.dart
+++ b/nexus/lib/widgets/sparkle.dart
@@ -61,12 +61,15 @@ class _SparkleState extends State<Sparkle>
           alignment: Alignment.center,
           width: size,
           height: size,
-          decoration: BoxDecoration(boxShadow: [
-            BoxShadow(
-              color: color.withOpacity(0.7),
-              blurRadius: 8 * t + 2,
-            )
-          ]),
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            boxShadow: [
+              BoxShadow(
+                color: color.withOpacity(0.7),
+                blurRadius: 8 * t + 2,
+              ),
+            ],
+          ),
           child: Icon(
             Icons.star,
             color: color,

--- a/nexus/lib/widgets/star_menu.dart
+++ b/nexus/lib/widgets/star_menu.dart
@@ -97,32 +97,19 @@ class _StarMenuState extends State<StarMenu> with SingleTickerProviderStateMixin
   }
 
   Widget _buildOption({required IconData icon, VoidCallback? onTap}) {
-    return Container(
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        gradient: const LinearGradient(
-          colors: [Colors.teal, Colors.blue],
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
+    return Material(
+      elevation: 8,
+      shape: const CircleBorder(),
+      color: Colors.transparent,
+      child: Ink(
+        decoration: const BoxDecoration(
+          shape: BoxShape.circle,
+          gradient: LinearGradient(
+            colors: [Colors.teal, Colors.blue],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
         ),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.4),
-            blurRadius: 12,
-            spreadRadius: 1,
-            offset: const Offset(0, 4),
-          ),
-          BoxShadow(
-            color: Colors.white.withOpacity(0.2),
-            blurRadius: 8,
-            spreadRadius: -2,
-            offset: const Offset(0, -2),
-          ),
-        ],
-      ),
-      child: Material(
-        color: Colors.transparent,
-        shape: const CircleBorder(),
         child: InkWell(
           customBorder: const CircleBorder(),
           onTap: onTap,


### PR DESCRIPTION
## Summary
- swap box shadows for material elevation in star menu options
- remove square shadow from language selector overlay
- render sparkle effect with round shadow

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac32a0abe08332bd6cebd8d38d661f