### PR TITLE
Refine menu shadows for circular feel

### DIFF
--- a/nexus/lib/widgets/language_selector.dart
+++ b/nexus/lib/widgets/language_selector.dart
@@ -146,7 +146,7 @@ class _LanguageSelectorState extends State<LanguageSelector> {
               const Positioned(
                 top: 6,
                 left: 10,
-                child: Sparkle(size: 10, color: Color(0xFFB39DDB)),
+                child: Sparkle(size: 10, color: Colors.white),
               ),
               const Positioned(
                 bottom: 6,

--- a/nexus/lib/widgets/sparkle.dart
+++ b/nexus/lib/widgets/sparkle.dart
@@ -61,12 +61,15 @@ class _SparkleState extends State<Sparkle>
           alignment: Alignment.center,
           width: size,
           height: size,
-          decoration: BoxDecoration(boxShadow: [
-            BoxShadow(
-              color: color.withOpacity(0.7),
-              blurRadius: 8 * t + 2,
-            )
-          ]),
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            boxShadow: [
+              BoxShadow(
+                color: color.withOpacity(0.7),
+                blurRadius: 8 * t + 2,
+              ),
+            ],
+          ),
           child: Icon(
             Icons.star,
             color: color,

--- a/nexus/lib/widgets/star_menu.dart
+++ b/nexus/lib/widgets/star_menu.dart
@@ -98,27 +98,13 @@ class _StarMenuState extends State<StarMenu> with SingleTickerProviderStateMixin
 
   Widget _buildOption({required IconData icon, VoidCallback? onTap}) {
     return Container(
-      decoration: BoxDecoration(
+      decoration: const BoxDecoration(
         shape: BoxShape.circle,
-        gradient: const LinearGradient(
+        gradient: LinearGradient(
           colors: [Colors.teal, Colors.blue],
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
         ),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.4),
-            blurRadius: 12,
-            spreadRadius: 1,
-            offset: const Offset(0, 4),
-          ),
-          BoxShadow(
-            color: Colors.white.withOpacity(0.2),
-            blurRadius: 8,
-            spreadRadius: -2,
-            offset: const Offset(0, -2),
-          ),
-        ],
       ),
       child: Material(
         color: Colors.transparent,


### PR DESCRIPTION
## Summary
- drop all shadows from star menu buttons for clean circular look
- restore language selector wheel overlay with white sparkle accent

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac32a0abe08332bd6cebd8d38d661f