### PR TITLE
Make map image fill entire screen

### DIFF
--- a/nexus/lib/map_page.dart
+++ b/nexus/lib/map_page.dart
@@ -9,12 +9,15 @@ class MapPage extends StatelessWidget {
     return Scaffold(
       body: Stack(
         children: [
-          InteractiveViewer(
-            maxScale: 5,
-            child: Image.asset(
-              '../assets/map.png',
-              fit: BoxFit.cover,
-              errorBuilder: (context, error, stack) => const Center(child: Text('Map image missing')),
+          Positioned.fill(
+            child: InteractiveViewer(
+              maxScale: 5,
+              child: Image.asset(
+                'assets/map.png',
+                fit: BoxFit.cover,
+                errorBuilder: (context, error, stack) =>
+                    const Center(child: Text('Map image missing')),
+              ),
             ),
           ),
           const Positioned(

--- a/nexus/pubspec.yaml
+++ b/nexus/pubspec.yaml
@@ -58,8 +58,8 @@ flutter:
   # the material Icons class.
   uses-material-design: true
 
-  # assets:
-  #   - assets/map.png
+  assets:
+    - assets/map.png
 
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Summary
- Ensure interactive map fills the entire screen by wrapping it with `Positioned.fill`
- Register `assets/map.png` and simplify asset path

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ada9d346548332b5184b3aa018b0fb